### PR TITLE
Use (time_t)0 as the "null" value for timestamps over -1.

### DIFF
--- a/squashfs-tools/mksquashfs.c
+++ b/squashfs-tools/mksquashfs.c
@@ -139,10 +139,10 @@ unsigned int cache_bytes = 0, cache_size = 0, inode_count = 0;
 squashfs_inode *inode_lookup_table = NULL;
 
 /* clamp all timestamps to SOURCE_DATE_EPOCH */
-time_t content_clamp_time = -1;
+time_t content_clamp_time = (time_t)0;
 
 /* override filesystem creation time */
-time_t mkfs_fixed_time = -1;
+time_t mkfs_fixed_time = (time_t)0;
 
 /* in memory directory data */
 #define I_COUNT_SIZE		128
@@ -2250,7 +2250,7 @@ restat:
 			  pathname_reader(dir_ent), strerror(errno));
 		goto read_err;
 	}
-	if(content_clamp_time != -1 && buf2.st_mtime >= content_clamp_time)
+	if(content_clamp_time && buf2.st_mtime >= content_clamp_time)
 		buf2.st_mtime = content_clamp_time;
 
 	if(read_size != buf2.st_size) {
@@ -3107,7 +3107,7 @@ void dir_scan(squashfs_inode *inode, char *pathname,
 		buf.st_mode = S_IRWXU | S_IRWXG | S_IRWXO | S_IFDIR;
 		buf.st_uid = getuid();
 		buf.st_gid = getgid();
-		buf.st_mtime = content_clamp_time != -1 ? content_clamp_time : time(NULL);
+		buf.st_mtime = content_clamp_time ? content_clamp_time : time(NULL);
 		buf.st_dev = 0;
 		buf.st_ino = 0;
 		dir_ent->inode = lookup_inode2(&buf, PSEUDO_FILE_OTHER, 0);
@@ -3116,7 +3116,7 @@ void dir_scan(squashfs_inode *inode, char *pathname,
 			/* source directory has disappeared? */
 			BAD_ERROR("Cannot stat source directory %s because %s\n",
 					  pathname, strerror(errno));
-		if(content_clamp_time != -1 && buf.st_mtime >= content_clamp_time)
+		if(content_clamp_time && buf.st_mtime >= content_clamp_time)
 			buf.st_mtime = content_clamp_time;
 		dir_ent->inode = lookup_inode(&buf);
 	}
@@ -3373,7 +3373,7 @@ struct dir_info *dir_scan1(char *filename, char *subpath,
 			free_dir_entry(dir_ent);
 			continue;
 		}
-		if(content_clamp_time != -1 && buf.st_mtime >= content_clamp_time)
+		if(content_clamp_time && buf.st_mtime >= content_clamp_time)
 			buf.st_mtime = content_clamp_time;
 
 		if((buf.st_mode & S_IFMT) != S_IFREG &&
@@ -3554,7 +3554,7 @@ void dir_scan2(struct dir_info *dir, struct pseudo *pseudo)
 		buf.st_gid = pseudo_ent->dev->gid;
 		buf.st_rdev = makedev(pseudo_ent->dev->major,
 							  pseudo_ent->dev->minor);
-		buf.st_mtime = content_clamp_time != -1 ? content_clamp_time : time(NULL);
+		buf.st_mtime = content_clamp_time ? content_clamp_time : time(NULL);
 		buf.st_ino = pseudo_ino ++;
 
 		if(pseudo_ent->dev->type == 'd') {
@@ -6021,7 +6021,7 @@ printOptions:
 	sBlk.flags = SQUASHFS_MKFLAGS(noI, noD, noF, noX, no_fragments,
 								  always_use_fragments, duplicate_checking, exportable,
 								  no_xattrs, comp_opts);
-	sBlk.mkfs_time = mkfs_fixed_time != -1 ? mkfs_fixed_time : time(NULL);
+	sBlk.mkfs_time = mkfs_fixed_time ? mkfs_fixed_time : time(NULL);
 
 	disable_info();
 


### PR DESCRIPTION
This prevents creating all filesystems at "Wed Dec 31 23:59:59 1969", at least according to:

  https://sources.debian.org/src/squashfs-tools/1:4.3-7/debian/changelog/#L14